### PR TITLE
Fixed app domains on compile-time validation.

### DIFF
--- a/MethodBoundaryAspect.Fody.UnitTests.TestAssembly/Aspects/CachedAspect.cs
+++ b/MethodBoundaryAspect.Fody.UnitTests.TestAssembly/Aspects/CachedAspect.cs
@@ -1,4 +1,5 @@
 ﻿using MethodBoundaryAspect.Fody.Attributes;
+using System;
 using System.Reflection;
 
 namespace MethodBoundaryAspect.Fody.UnitTests.TestAssembly.Aspects
@@ -6,9 +7,9 @@ namespace MethodBoundaryAspect.Fody.UnitTests.TestAssembly.Aspects
     [AspectCaching(Caching.StaticByMethod)]
     public sealed class CachedAspect : OnMethodBoundaryAspect
     {
-        public override bool CompileTimeValidate(MethodBase method)
+        public override bool CompileTimeValidate(Type type, MethodInfo method)
         {
-            return ((MethodInfo)method).ReturnType == typeof(int);
+            return method.ReturnType == typeof(Int32);
         }
 
         int m_enterCalled;

--- a/MethodBoundaryAspect.Fody.UnitTests.TestAssembly/Aspects/ValidatableAspect.cs
+++ b/MethodBoundaryAspect.Fody.UnitTests.TestAssembly/Aspects/ValidatableAspect.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using MethodBoundaryAspect.Fody.Attributes;
 
 namespace MethodBoundaryAspect.Fody.UnitTests.TestAssembly.Aspects
@@ -15,7 +16,7 @@ namespace MethodBoundaryAspect.Fody.UnitTests.TestAssembly.Aspects
             return tmp;
         }
 
-        public override bool CompileTimeValidate(MethodBase method)
+        public override bool CompileTimeValidate(Type type, MethodInfo method)
         {
             return !method.Name.Contains("XXX");
         }

--- a/MethodBoundaryAspect.Fody.UnitTests.TestAssembly/Aspects/ValidatedAspect.cs
+++ b/MethodBoundaryAspect.Fody.UnitTests.TestAssembly/Aspects/ValidatedAspect.cs
@@ -1,4 +1,5 @@
 ﻿using MethodBoundaryAspect.Fody.Attributes;
+using System;
 using System.Reflection;
 
 namespace MethodBoundaryAspect.Fody.UnitTests.TestAssembly.Aspects
@@ -17,7 +18,7 @@ namespace MethodBoundaryAspect.Fody.UnitTests.TestAssembly.Aspects
             Called = true;
         }
 
-        public override bool CompileTimeValidate(MethodBase method)
+        public override bool CompileTimeValidate(Type type, MethodInfo method)
         {
             if (_intercept == true || InterceptProperty == true || InterceptField == true)
                 return true;

--- a/MethodBoundaryAspect.Fody/AssemblyLoadData.cs
+++ b/MethodBoundaryAspect.Fody/AssemblyLoadData.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace MethodBoundaryAspect.Fody
+{
+    [Serializable]
+    public class AssemblyLoadData
+    {
+        public byte[] AssemblyContents { get; set; }
+        public List<string> ReferencePaths { get; set; }
+
+        public void LoadAssembly()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve += UnweavedCodeRunner.CurrentDomain_AssemblyResolve;
+            HashSet<string> loaded = new HashSet<string>();
+            Assembly LoadAssembly(byte[] contents)
+            {
+                var asm = Assembly.Load(contents);
+                foreach (var dependent in asm.GetReferencedAssemblies())
+                    if (!loaded.Contains(dependent.FullName))
+                    {
+                        var referencePath = ReferencePaths.FirstOrDefault(p =>
+                            new FileInfo(p).Name == dependent.Name + ".dll" ||
+                            new FileInfo(p).Name == dependent.Name + ".exe");
+                        loaded.Add(dependent.FullName);
+                        if (referencePath == null)
+                            Assembly.Load(dependent);
+                        else
+                            LoadAssembly(File.ReadAllBytes(referencePath));
+                    }
+                return asm;
+            }
+            LoadAssembly(AssemblyContents);
+        }
+    }
+}

--- a/MethodBoundaryAspect.Fody/CecilExtensions.cs
+++ b/MethodBoundaryAspect.Fody/CecilExtensions.cs
@@ -105,6 +105,7 @@ namespace MethodBoundaryAspect.Fody
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Text;
     using Mono.Cecil;
     using Mono.Cecil.Cil;
@@ -198,6 +199,16 @@ namespace MethodBoundaryAspect.Fody
                 default:
                     return OpCodes.Stelem_Ref;
             }
+        }
+
+        public static string ToAssemblyQualifiedTypeName(this TypeReference typeRef, ModuleDefinition module)
+        {
+            string typeName = $"{typeRef.Namespace}.{typeRef.Name}";
+            if (typeRef is GenericInstanceType gen)
+                typeName += $"[{String.Join(",", gen.GenericArguments.Select(p => $"[{p.ToAssemblyQualifiedTypeName(module)}]"))}]";
+            typeName += ", ";
+            typeName += module.ImportReference(typeRef).Resolve().Module.Assembly.FullName;
+            return typeName;
         }
     }
 }

--- a/MethodBoundaryAspect.Fody/CompileTimeValidationData.cs
+++ b/MethodBoundaryAspect.Fody/CompileTimeValidationData.cs
@@ -1,0 +1,59 @@
+﻿using MethodBoundaryAspect.Fody.Attributes;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection.Emit;
+
+namespace MethodBoundaryAspect.Fody
+{
+    [Serializable]
+    public class CompileTimeValidationData
+    {
+        public string AspectType { get; set; }
+        public int ConstructorToken { get; set; }
+        public byte[] Blob { get; set; }
+        public string TypeBeingWoven { get; set; }
+        public string TypeDeclaringMethod { get; set; }
+        public int MethodToken { get; set; }
+        
+        static int NextType;
+
+        public void Validate()
+        {
+            var data = this;
+
+            Type aspectType = Type.GetType(data.AspectType);
+            if (aspectType == null)
+                throw new InvalidDataException("Could not find aspect type: " + data.AspectType);
+            var ctor = aspectType.GetConstructors().FirstOrDefault(c => c.MetadataToken == data.ConstructorToken);
+            if (ctor == null)
+                throw new InvalidDataException("Could not find constructor for aspect.");
+
+            var mod = AssemblyBuilder.DefineDynamicAssembly(new System.Reflection.AssemblyName("Tmp.dll"), System.Reflection.Emit.AssemblyBuilderAccess.Run).DefineDynamicModule("Tmp.dll");
+            var t = mod.DefineType((++NextType).ToString(), System.Reflection.TypeAttributes.Sealed | System.Reflection.TypeAttributes.Abstract);
+            t.SetCustomAttribute(ctor, data.Blob);
+            var tmpType = t.CreateType();
+            var aspect = tmpType.GetCustomAttributes(false)
+                .OfType<OnMethodBoundaryAspect>()
+                .Single();
+            if (aspect == null)
+                throw new InvalidOperationException("Could not find aspect on created type.");
+            Type beingWoven = Type.GetType(data.TypeBeingWoven);
+            if (beingWoven == null)
+                throw new InvalidOperationException("Could not find type being woven: " + data.TypeBeingWoven);
+            Type declaringMethod = Type.GetType(data.TypeDeclaringMethod);
+            if (declaringMethod == null)
+                throw new InvalidOperationException("Could not find type declaring the method: " + data.TypeDeclaringMethod);
+            var m = declaringMethod.GetMethods(System.Reflection.BindingFlags.Public |
+                System.Reflection.BindingFlags.Static |
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.FlattenHierarchy)
+                .FirstOrDefault(md => md.MetadataToken == data.MethodToken);
+            if (m == null)
+                throw new InvalidOperationException($"Cannot find method on type {declaringMethod.FullName} with token {data.MethodToken}");
+
+            AppDomain.CurrentDomain.SetData("result", aspect.CompileTimeValidate(beingWoven, m));
+        }
+    }
+}

--- a/MethodBoundaryAspect.Fody/MethodWeaver.cs
+++ b/MethodBoundaryAspect.Fody/MethodWeaver.cs
@@ -1,32 +1,17 @@
-using MethodBoundaryAspect.Fody.Attributes;
 using Mono.Cecil;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 
 namespace MethodBoundaryAspect.Fody
 {
     internal class MethodWeaver : IDisposable
     {
-        internal MethodWeaver(ModuleDefinition moduleDefinition, TypeReference typeBeingWoven, MethodDefinition method, Assembly loadedAssembly)
+        internal MethodWeaver(ModuleDefinition moduleDefinition, TypeReference typeBeingWoven, MethodDefinition method)
         {
             _typeBeingWoven = typeBeingWoven;
             _moduleDefinition = moduleDefinition;
             _method = method;
-
-            string[] methodParams = _method.Parameters.Select(p => ToAssemblyQualifiedTypeName(p.ParameterType, _moduleDefinition)).ToArray();
-
-            var typeInfo = loadedAssembly.GetTypes().FirstOrDefault(t => t.FullName == _typeBeingWoven.FullName);
-            if (typeInfo == null)
-                throw new InvalidOperationException(String.Format("Could not find type '{0}'.", _typeBeingWoven.FullName));
-
-            Type[] parameters = methodParams.Select(Type.GetType).ToArray();
-            _methodInfo = typeInfo.GetMethod(_method.Name,
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance,
-                null,
-                parameters,
-                new ParameterModifier[0]);
         }
 
         private MethodDefinition _method;
@@ -35,7 +20,6 @@ namespace MethodBoundaryAspect.Fody
         private NamedInstructionBlockChain _createArgumentsArray;
         private MethodBodyPatcher _methodBodyChanger;
         private bool _finished;
-        private MethodInfo _methodInfo;
 
         public int WeaveCounter { get; private set; }
         
@@ -56,56 +40,15 @@ namespace MethodBoundaryAspect.Fody
                     return arg.Value;
             }
         }
-
-        string ToAssemblyQualifiedTypeName(TypeReference typeRef, ModuleDefinition module)
-        {
-            string typeName = $"{typeRef.Namespace}.{typeRef.Name}";
-            if (typeRef is GenericInstanceType gen)
-                typeName += $"[[{String.Join(",", gen.GenericArguments.Select(p => ToAssemblyQualifiedTypeName(p, module)))}]]";
-            typeName += ", ";
-            typeName += module.ImportReference(typeRef).Resolve().Module.Assembly.FullName;
-            return typeName;
-        }
-
-        public void Weave(CustomAttribute aspect, AspectMethods overriddenAspectMethods)
+        
+        public void Weave(CustomAttribute aspect, AspectMethods overriddenAspectMethods, string typeName, int methodToken, Validator compileTimeValidate)
         {
             if (overriddenAspectMethods == AspectMethods.None)
                 return;
 
             if (overriddenAspectMethods.HasFlag(AspectMethods.CompileTimeValidate))
             {
-                string[] ctorParams = aspect.Constructor.Parameters.Select(p => p.ParameterType.FullName).ToArray();
-
-                Type aspectType = Type.GetType(ToAssemblyQualifiedTypeName(aspect.AttributeType, _moduleDefinition));
-                if (aspectType == null)
-                    throw new InvalidOperationException("Could not find aspect type: " + aspect.AttributeType.FullName);
-                
-                var ctorInfo = aspectType.GetConstructor(ctorParams.Select(Type.GetType).ToArray());
-                if (ctorInfo == null)
-                    throw new InvalidOperationException("Could not find constructor for aspect.");
-
-                object[] ctorArgs = GetRuntimeAttributeArgs(aspect.ConstructorArguments);
-                var aspectInstance = ctorInfo.Invoke(ctorArgs) as OnMethodBoundaryAspect;
-                if (aspectInstance == null)
-                    throw new InvalidOperationException("Could not create aspect.");
-
-                foreach (var fieldSetter in aspect.Fields)
-                {
-                    var field = aspectType.GetField(fieldSetter.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-                    if (field == null)
-                        throw new InvalidOperationException(String.Format("Could not find field named {0}", fieldSetter.Name));
-                    field.SetValue(aspectInstance, fieldSetter.Argument.Value);
-                }
-
-                foreach (var propSetter in aspect.Properties)
-                {
-                    var prop = aspectType.GetProperty(propSetter.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-                    if (prop == null)
-                        throw new InvalidOperationException(String.Format("Could not find property named {0}", propSetter.Name));
-                    prop.SetValue(aspectInstance, propSetter.Argument.Value);
-                }
-
-                if (!aspectInstance.CompileTimeValidate(_methodInfo))
+                if (!compileTimeValidate(aspect, _typeBeingWoven, typeName, methodToken))
                     return;
             }
 

--- a/MethodBoundaryAspect.Fody/UnweavedCodeRunner.cs
+++ b/MethodBoundaryAspect.Fody/UnweavedCodeRunner.cs
@@ -1,0 +1,69 @@
+﻿using Mono.Cecil;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace MethodBoundaryAspect.Fody
+{
+    public class UnweavedCodeRunner : IDisposable
+    {
+        const string DataKey = "data";
+        const string ResultKey = "result";
+        AppDomain _appDomain;
+        ModuleDefinition _module;
+        Action<string> _logger;
+
+        void IDisposable.Dispose()
+        {
+            AppDomain.Unload(_appDomain);
+        }
+
+        public UnweavedCodeRunner(ModuleDefinition module, string addinPath, byte[] unweavedAssembly, List<string> otherReferencePaths, Action<string> logger)
+        {
+            _module = module;
+            var setup = AppDomain.CurrentDomain.SetupInformation;
+            if (addinPath != null)
+                setup = new AppDomainSetup()
+                {
+                    ShadowCopyFiles = "true",
+                    ApplicationBase = addinPath
+                };
+            _appDomain = AppDomain.CreateDomain("unweavedCodeDomain", null, setup);
+            _logger = logger;
+
+            var loader = new AssemblyLoadData()
+            {
+                AssemblyContents = unweavedAssembly,
+                ReferencePaths = otherReferencePaths ?? new List<string>()
+            };
+
+            _appDomain.DoCallBack(loader.LoadAssembly);
+        }
+
+        public static Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            return ((AppDomain)sender).GetAssemblies().FirstOrDefault(a => a.FullName == args.Name);
+        }
+
+        static UnweavedCodeRunner()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
+        }
+        
+        public bool CompileTimeValidate(CustomAttribute attribute, TypeReference type, string typeName, int methodtoken)
+        {
+            var data = new CompileTimeValidationData();
+            data.AspectType = attribute.AttributeType.ToAssemblyQualifiedTypeName(_module);
+            data.Blob = attribute.GetBlob();
+            data.ConstructorToken = attribute.Constructor.MetadataToken.ToInt32();
+            data.MethodToken = methodtoken;
+            data.TypeBeingWoven = type.ToAssemblyQualifiedTypeName(_module);
+            data.TypeDeclaringMethod = typeName;
+
+            _appDomain.DoCallBack(data.Validate);
+
+            return (bool)_appDomain.GetData("result");
+        }
+    }
+}

--- a/MethodBoundaryAspect/Attributes/OnMethodBoundaryAspect.cs
+++ b/MethodBoundaryAspect/Attributes/OnMethodBoundaryAspect.cs
@@ -18,7 +18,7 @@ namespace MethodBoundaryAspect.Fody.Attributes
         {
         }
 
-        public virtual bool CompileTimeValidate(MethodBase method)
+        public virtual bool CompileTimeValidate(Type typeBeingWoven, MethodInfo method)
         {
             return true;
         }


### PR DESCRIPTION
Sending this to the .net 4.5 branch because .net standard does not support some features used in this implementation, like the Reflection.Emit namespace and the AppDomainSetup class.